### PR TITLE
Add horizontal scrolling. Fixes #14

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ QuantumVim is a vim key-binding add-on for Firefox. It is targeting future Firef
 
 # Supported commands
 * `j`, `k`: scroll down/up by one line
+* `h`, `l`: scroll left/right
 * `J`, `K`: switch to previous/next tab
 * `r`, `R`: reload page (`R` bypass the local web cache)
 * `gg`, `G`: go to the top/bottom of the page
@@ -24,7 +25,6 @@ QuantumVim is a vim key-binding add-on for Firefox. It is targeting future Firef
 * `I`: enter INSERT MODE manually
 
 # TODO:
-* `h`, `l`: scroll
 * `:open`: open an URL or search
 * `:tabopen`: open an URL or search in a new tab
 * `F`: follow links in a new tab

--- a/vim.js
+++ b/vim.js
@@ -21,12 +21,18 @@ document.addEventListener('keypress', function(evt){
     case "NORMAL":
       // TODO: extract the command <-> action mapping to a config file
       switch (keyStr) {
-        case 'j':
+        case 'h':
           // TODO: make the scroll configurable
+          window.scrollBy(-19, 0);
+          break;
+        case 'j':
           window.scrollByLines(1);
           break;
         case 'k':
           window.scrollByLines(-1);
+          break;
+        case 'l':
+          window.scrollBy(19, 0);
           break;
         case 'g':
           gState.set("GOTO");
@@ -35,12 +41,10 @@ document.addEventListener('keypress', function(evt){
           window.scrollTo(window.scrollX, document.body.scrollHeight);
           break;
         case 'J':
-          // TODO: make the scroll configurable
           //chrome.tabs.update(1, {selected: true});
           chrome.runtime.sendMessage({type:'switch_tab_left'});
           break;
         case 'K':
-          // TODO: make the scroll configurable
           chrome.runtime.sendMessage({type:'switch_tab_right'});
           break;
         case 'H':


### PR DESCRIPTION
Fixes #14.

Vertical scrolling scrolls the page by 19px per keystroke as it can be seen this way:
1. Using the developer tools' js console, write `window.scrollY`.
2. Scroll down by pressing `j` on the page.
3. Write `window.scrollY` to the console again and see that it's now 19px more than in step 1.

19px horizontal scrolling per keystroke looks good in my opinion.
