### PR TITLE
Change in hinting characters and bug fixes

### DIFF
--- a/vim-background.js
+++ b/vim-background.js
@@ -21,14 +21,14 @@ chrome.runtime.onMessage.addListener(
 
       case "zoom_in":
         chrome.tabs.getZoom(function(curr_zoom){
-          var target_zoom = Math.min(curr_zoom * 1.08, 3.0)
+          var target_zoom = Math.min(curr_zoom * 1.08, 3.0);
           chrome.tabs.setZoom(target_zoom);
         });
         break;
 
       case "zoom_out":
         chrome.tabs.getZoom(function(curr_zoom){
-          var target_zoom = Math.max(curr_zoom * 0.92, 0.3)
+          var target_zoom = Math.max(curr_zoom * 0.92, 0.3);
           chrome.tabs.setZoom(target_zoom);
         });
         break;

--- a/vim.js
+++ b/vim.js
@@ -56,8 +56,9 @@ function debounce(keyStr) {
 }
 
 document.addEventListener('keypress', function(evt){
-
-  let keyStr = (evt.ctrlKey ? "C-" : "") + evt.key;
+  let keyStr = evt.key;
+  if (evt.ctrlKey) keyStr = 'C-' + keyStr;
+  if (evt.metaKey) keyStr = 'M-' + keyStr;
 
   debounce(keyStr);
 

--- a/vim.js
+++ b/vim.js
@@ -102,15 +102,8 @@ document.addEventListener('keypress', function(evt){
           highlight_links();
           gState.set("FOLLOW");
           break;
-        case 'r':
-          confirmOrGoToInsert("Refresh the tab?", function(){
-            chrome.runtime.sendMessage({ type: 'reload', bypassCache: false });
-          });
-          break;
         case 'R':
-          confirmOrGoToInsert("Refresh the tab without cache?", function(){
-            chrome.runtime.sendMessage({ type: 'reload', bypassCache: true });
-          });
+          chrome.runtime.sendMessage({ type: 'reload', bypassCache: false });
           break;
         case 'y':
           copyCurrentLocation();
@@ -248,6 +241,16 @@ function copyCurrentLocation() {
   copyToClipboard(window.location.href);
 }
 
+function link_hint_code_to_letters(code) {
+  var map = "qewrtasdfgzxcvb";
+  var out = '';
+  do {
+    out = map[code % map.length] + out;
+    code /= map.length;
+  } while (code > 0);
+  return out;
+}
+
 /* Link Following */
 function highlight_links() {
   // TODO: buttons, inputs
@@ -261,7 +264,7 @@ function highlight_links() {
     elem.style.backgroundColor = 'yellow';
 
     var codehint = document.createElement('span');
-    codehint.textContent = code;
+    codehint.textContent = link_hint_code_to_letters(code);
     codehint.style.border="solid 1px black";
     codehint.style.backgroundColor="white";
     codehint.style.font="12px/14px bold sans-serif";
@@ -274,7 +277,7 @@ function highlight_links() {
     elem.style.position="relative";
     elem.appendChild(codehint);
 
-    gLinkCodes[String(code)] = {
+    gLinkCodes[link_hint_code_to_letters(code)] = {
       'element':elem,
       'codehint': codehint
     };
@@ -293,11 +296,6 @@ function reduce_highlights(remain_pattern) {
 }
 
 function accumulate_link_codes(keyStr){
-
-  // TODO: make this more generic, handle chars
-  if (!(/^[0-9]$/.test(keyStr))){
-    return;
-  }
   gKeyQueue += keyStr;
   newGLinkCodes = {};
   for (var code in gLinkCodes){

--- a/vim.js
+++ b/vim.js
@@ -241,31 +241,31 @@ function copyCurrentLocation() {
   copyToClipboard(window.location.href);
 }
 
-function link_hint_code_to_letters(code) {
-  var map = "qewrtasdfgzxcvb";
-  var out = '';
-  do {
-    out = map[code % map.length] + out;
-    code /= map.length;
-  } while (code > 0);
-  return out;
-}
 
 /* Link Following */
 function highlight_links() {
   // TODO: buttons, inputs
   var links = document.querySelectorAll('a');
-  // TODO: asdfghjkl; codes
+  function hint_code_to_letters(code) {
+    var map = "qewrtasdfgzxcvb";
+    var out = '';
+    do {
+      out = '' + map[code % map.length] + out;
+      code = code / map.length | 0;
+    } while (code > 0);
+    return out;
+  }
+
   var code = 0;
-  Array.prototype.forEach.call(links, function(elem){
+  Array.prototype.forEach.call(links, function(elem) {
 
     elem._originalBackgroundColor = elem.style.backgroundColor;
     elem._originalPosition = elem.style.position;
     elem.style.backgroundColor = 'yellow';
 
     var codehint = document.createElement('span');
-    codehint.textContent = link_hint_code_to_letters(code);
-    codehint.style.border="solid 1px black";
+    codehint.textContent = hint_code_to_letters(code);
+    codehint.style.border="solid 0.2px black";
     codehint.style.backgroundColor="white";
     codehint.style.font="12px/14px bold sans-serif";
     codehint.style.color="darkred";
@@ -277,7 +277,7 @@ function highlight_links() {
     elem.style.position="relative";
     elem.appendChild(codehint);
 
-    gLinkCodes[link_hint_code_to_letters(code)] = {
+    gLinkCodes[hint_code_to_letters(code)] = {
       'element':elem,
       'codehint': codehint
     };


### PR DESCRIPTION
- Link hinting now takes alphabets from left-hand-side part of the keyboard instead of numbers
- Remove the prompt for refreshing pages
- Prevent it from triggering 'f' link hinting when pressing keys like 'Cmd+f'